### PR TITLE
Keypress events are less obstructive

### DIFF
--- a/js/synth.js
+++ b/js/synth.js
@@ -275,6 +275,11 @@ document.addEventListener( "keydown", function(event) {
     return false;
   }
 
+  // bail, if a modifier is pressed alongside the key
+  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+    return false;
+  }
+
   const midiNote = keycode_to_midinote( event.which ); // midi note number 0-127
   const velocity = 100
 
@@ -286,6 +291,10 @@ document.addEventListener( "keydown", function(event) {
 
 // KEYUP -- capture keyboard input
 document.addEventListener( "keyup", function(event) {
+  // bail, if a modifier is pressed alongside the key
+  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+    return false;
+  }
   const midiNote = keycode_to_midinote( event.which )
   if (midiNote !== false) {
     event.preventDefault();

--- a/js/synth.js
+++ b/js/synth.js
@@ -275,17 +275,22 @@ document.addEventListener( "keydown", function(event) {
     return false;
   }
 
-  event.preventDefault();
-  Synth.noteOn(
-    keycode_to_midinote( event.which ), // midi note number 0-127
-    100 // note velocity 0-127
-  );
+  const midiNote = keycode_to_midinote( event.which ); // midi note number 0-127
+  const velocity = 100
+
+  if (midiNote !== false)  {
+    event.preventDefault();
+    Synth.noteOn( midiNote, velocity );
+  }
 });
 
 // KEYUP -- capture keyboard input
 document.addEventListener( "keyup", function(event) {
-  event.preventDefault();
-  Synth.noteOff( keycode_to_midinote( event.which ) );
+  const midiNote = keycode_to_midinote( event.which )
+  if (midiNote !== false) {
+    event.preventDefault();
+    Synth.noteOff( midiNote );
+  }
 });
 
 // TOUCHSTART -- virtual keyboard


### PR DESCRIPTION
Not every keyboard input needs to be captured. With this fix the devtools in the browser can be opened again and also the page can be refreshed.