### PR TITLE
Eval removal

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -623,6 +623,7 @@ Example 8edo:
     <script src="inc/eventemitter3.js"></script>
 
     <!-- Scale Workshop scripts -->
+    <script src="js/constants.js"></script>
     <script src="js/scaleworkshop.js"></script>
     <script src="js/helpers.js"></script>
     <script src="js/ui.js"></script>

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,0 +1,8 @@
+const LINE_TYPE = {
+  CENTS: 'cents',
+  RATIO: 'ratio',
+  N_OF_EDO: 'n of edo',
+  INVALID: 'invalid'
+}
+
+const SEMITONE_RATIO_IN_12_EDO = Math.pow(2, 1 / 12)

--- a/js/exporters.js
+++ b/js/exporters.js
@@ -101,7 +101,7 @@ function export_scala_scl() {
   for ( i = 1; i < tuning_table['note_count']; i++ ) {
 
     // if the current interval is n-of-m edo type, output as cents instead
-    if ( line_type( tuning_table['scale_data'][i] ) == 'n_of_edo' ) {
+    if ( getLineType( tuning_table['scale_data'][i] ) === LINE_TYPE.N_OF_EDO  ) {
       file += " " + decimal_to_cents( tuning_table['tuning_data'][i] ).toFixed(6) + newline;
     }
     else {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -348,3 +348,20 @@ function getCoordsFromKey(tdOfKeyboard) {
     return []
   }
 }
+
+// Runs the given function with the supplied value, then returns the value
+// This is a great tool for injecting debugging in the middle of expressions
+// Note: fn does not need to return the value, tap will handle that
+//
+// example 1: const result = toString(tap(function(result){ debug(result) }, 3 * 5))
+// example 2: const result = toString(tap(result => debug(result), 3 * 5))
+// example 3: const result = toString(tap(debug, 3 * 5))
+//
+// the above examples are equal to:
+//   let result = 3 * 5
+//   debug(result)
+//   result = toString(result)
+function tap(fn, value) {
+  fn(value)
+  return value
+}

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -357,3 +357,12 @@ function setTuningData(tuning) {
 const isEmpty = string => string === ''
 const isNil = x => typeof x === 'undefined' || x === null
 const isFunction = x => typeof x === 'function'
+
+function getCoordsFromKey(tdOfKeyboard) {
+  try {
+    const [row, col] = JSON.parse(tdOfKeyboard.getAttribute('data-coord'))
+    return { row, col }
+  } catch (e) {
+    return { row: null, col: null }
+  }
+}

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -360,9 +360,8 @@ const isFunction = x => typeof x === 'function'
 
 function getCoordsFromKey(tdOfKeyboard) {
   try {
-    const [row, col] = JSON.parse(tdOfKeyboard.getAttribute('data-coord'))
-    return { row, col }
+    return JSON.parse(tdOfKeyboard.getAttribute('data-coord'))
   } catch (e) {
-    return { row: null, col: null }
+    return []
   }
 }

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -49,7 +49,7 @@ function n_of_edo_to_decimal(rawInput) {
     const [val1, val2] = input.split('/').map(x => parseInt(x))
     return Math.pow(2, val1 / val2);
   } else {
-    alert("Invalid input: " + input);
+    alert("Invalid input: " + rawInput);
     return false
   }
 }

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -8,141 +8,118 @@ Number.prototype.mod = function (n) {
 };
 
 // convert a cents value to decimal
-function cents_to_decimal(input) {
+function cents_to_decimal(rawInput) {
+  const input = trim(toString(rawInput))
   return Math.pow(2, (parseFloat(input) / 1200.0));
 }
 
 // convert a ratio (string 'x/y') to decimal
-function ratio_to_decimal(input) {
-  try {
-    return eval(input);
-  }
-  catch (err) {
-    console.log(err);
-    alert("Warning: could not parse " + input);
-    return false;
+function ratio_to_decimal(rawInput) {
+  if (isRatio(rawInput)) {
+    const input = trim(toString(rawInput))
+    const [val1, val2] = input.split('/')
+    return val1 / val2
+  } else {
+    alert("Invalid input: " + input);
+    return false
   }
 }
 
-// convert a decimal value to cents
-function decimal_to_cents(input) {
-  input = parseFloat(input);
-  // check input
-  if (input == 0 || isNaN(input)) {
-    // fail
-    return false;
+function decimal_to_cents(rawInput) {
+  if (rawInput === false) {
+    return false
   }
-  else {
-    // success
+  const input = parseFloat(rawInput);
+  if (input === 0 || isNaN(input)) {
+    return false;
+  } else {
     return 1200.0 * Math.log2(input);
   }
 }
 
 // convert a ratio to cents
-function ratio_to_cents(input) {
-  return decimal_to_cents(ratio_to_decimal(input));
+function ratio_to_cents(rawInput) {
+  return decimal_to_cents(ratio_to_decimal(rawInput));
 }
 
 // convert an n-of-m-edo (string 'x\y') to decimal
-function n_of_edo_to_decimal(input) {
-  input = input.split("\\");
-  if (input.length > 2) {
+function n_of_edo_to_decimal(rawInput) {
+  if (isNOfEdo(rawInput)) {
+    const input = trim(toString(rawInput))
+    const [val1, val2] = input.split('/').map(x => parseInt(x))
+    return Math.pow(2, val1 / val2);
+  } else {
     alert("Invalid input: " + input);
-    return false;
+    return false
   }
-  return Math.pow(2, parseInt(input[0]) / parseInt(input[1]));
 }
 
 // convert an n-of-m-edo (string 'x\y') to cents
-function n_of_edo_to_cents(input) {
-  return decimal_to_cents(n_of_edo_to_decimal(input));
+function n_of_edo_to_cents(rawInput) {
+  return decimal_to_cents(n_of_edo_to_decimal(rawInput));
 }
 
-// return cents, ratio or n_of_edo depending on the format of inputted value 'line'
-function line_type(input) {
+function isCent(rawInput) {
+  // true, when the input has numbers at the beginning, followed by a dot, ending with any number of numbers
+  // for example: 700.00
+  const input = trim(toString(rawInput))
+  return /^\d+\.\d*$/.test(input)
+}
 
-  // line_type() examples:
-  //
-  // line_type("700.00") -> "cents"
-  // line_type("3/2")    -> "ratio"
-  // line_type("7\12")   -> "n_of_edo"
-  // line_type("Hello")  -> false
+function isNOfEdo(rawInput) {
+  // true, when the input has numbers at the beginning and the end, separated by a single backslash
+  // for example: 7\12
+  const input = trim(toString(rawInput))
+  return /^\d+\\\d+$/.test(input)
+}
 
-  // line contains a period, so it should be a value in cents
-  if (input.toString().includes('.')) {
-    try {
-      eval(input);
-    }
-    catch (err) {
-      console.log(err);
-      return false;
-    }
-    return "cents";
+function isRatio(rawInput) {
+  // true, when the input has numbers at the beginning and the end, separated by a single slash
+  // for example: 3/2
+  const input = trim(toString(rawInput))
+  return /^\d+\/\d+$/.test(input)
+}
+
+function getLineType(rawInput) {
+  if (isCent(rawInput)) {
+    return LINE_TYPE.CENTS
+  } else if (isNOfEdo(rawInput)) {
+    return LINE_TYPE.N_OF_EDO
+  } else if (isRatio(rawInput)) {
+    return LINE_TYPE.RATIO
+  } else {
+    return LINE_TYPE.INVALID
   }
-
-  // line contains a backslash, so it should be an n_of_edo
-  else if (input.toString().includes('\\')) {
-    return "n_of_edo";
-  }
-
-  // line contains a forward slash, so it should be a ratio
-  else if (input.toString().includes('/')) {
-    return "ratio";
-  }
-
-  // line contains something else, if it evaluates then just call it a ratio, otherwise fail
-  else {
-
-    try {
-      eval(input);
-    }
-    catch (err) {
-      console.log(err);
-      return false;
-    }
-
-    return "ratio";
-
-  }
-
 }
 
 // convert any input 'line' to decimal
-function line_to_decimal(input) {
+function line_to_decimal(rawInput) {
+  let converterFn = () => false
 
-  var type = line_type(input);
-
-  switch (type) {
-
-    case false:
-      return false;
-      break;
-
-    case "cents":
-      return cents_to_decimal(input);
-      break;
-
-    case "n_of_edo":
-      return n_of_edo_to_decimal(input);
-      break;
-
-    case "ratio":
-      return ratio_to_decimal(input);
-      break;
-
+  switch (getLineType(rawInput)) {
+    case LINE_TYPE.CENTS:
+      converterFn = cents_to_decimal
+      break
+    case LINE_TYPE.N_OF_EDO:
+      converterFn = n_of_edo_to_decimal
+      break
+    case LINE_TYPE.RATIO:
+      converterFn = ratio_to_decimal
+      break
   }
 
+  return converterFn(rawInput)
 }
 
 // convert any input 'line' to a cents value
-function line_to_cents(input) {
-  return decimal_to_cents(line_to_decimal(input));
+function line_to_cents(rawInput) {
+  return decimal_to_cents(line_to_decimal(rawInput));
 }
 
 // convert a midi note number to a frequency in Hertz
 // assuming 12-edo at 1440Hz (100% organic vanilla)
 function mtof(input) {
-  return 8.17579891564 * Math.pow(1.05946309436, parseInt(input));
+  return 8.17579891564 * Math.pow(SEMITONE_RATIO_IN_12_EDO, parseInt(input));
 }
 
 // convert a frequency to a midi note number and cents offset
@@ -334,7 +311,7 @@ function getString(id, errorMessage) {
 function getLine(id, errorMessage) {
   var value = jQuery(id).val();
 
-  if (isEmpty(value) || parseFloat(value) <= 0 || isNil(value) || line_type(value) == false) {
+  if (isEmpty(value) || parseFloat(value) <= 0 || isNil(value) || getLineType(value) === LINE_TYPE.INVALID) {
     alert(errorMessage);
     return false;
   }
@@ -355,8 +332,14 @@ function setTuningData(tuning) {
 }
 
 const isEmpty = string => string === ''
+
 const isNil = x => typeof x === 'undefined' || x === null
+
 const isFunction = x => typeof x === 'function'
+
+const toString = input => input + ''
+
+const trim = input => input.trim()
 
 function getCoordsFromKey(tdOfKeyboard) {
   try {

--- a/js/modifiers.js
+++ b/js/modifiers.js
@@ -25,32 +25,19 @@ function modify_stretch() {
   // strip out the unusable lines, assemble a multi-line string which will later replace the existing tuning data
   let new_tuning_lines = [];
   for ( var i = 0; i < lines.length; i++ ) {
-
-    // check that line is not empty
-    if ( !isEmpty(lines[i]) ) {
-
-      // evaluate the line first
-      try {
-        eval( lines[i] );
+    const line = trim(toString(lines[i]))
+    if ( !isEmpty(line) ) {
+      switch (getLineType(line)) {
+        case LINE_TYPE.INVALID:
+          return false
+        case LINE_TYPE.CENT:
+          new_tuning_lines.push(( parseFloat( line ) * stretch_ratio ).toFixed(5));
+          break
+        case LINE_TYPE.N_OF_EDO:
+        case LINE_TYPE.RATIO:
+          new_tuning_lines.push(( ratio_to_cents( line ) * stretch_ratio ).toFixed(5));
       }
-      // if line doesn't evaluate then bail
-      catch(err) {
-        console.log(err);
-        return false;
-      }
-      // so far so good!
-
-      // line contains a period, so it should be a value in cents
-      if ( lines[i].toString().includes('.')) {
-        new_tuning_lines.push(( parseFloat( lines[i] ) * stretch_ratio ).toFixed(5));
-      }
-      // line doesn't contain a period, so it is a ratio
-      else {
-        new_tuning_lines.push(( ratio_to_cents( lines[i] ) * stretch_ratio ).toFixed(5));
-      }
-
     }
-
   }
 
   // update tuning input field with new tuning
@@ -235,6 +222,7 @@ function modify_key_transpose() {
   // I will come back to this later... it's going to require some thinking with regards to just ratios...
   return false;
 
+  /*
   // remove white space from tuning data field
   jQuery( "#txt_tuning_data" ).val( jQuery( "#txt_tuning_data" ).val().trim() );
 
@@ -289,5 +277,5 @@ function modify_key_transpose() {
 
   // success
   return true;
-
+  */
 }

--- a/js/scaleworkshop.js
+++ b/js/scaleworkshop.js
@@ -214,7 +214,7 @@ function parse_tuning_data() {
     // check that line is not empty
     if ( !isEmpty(lines[i]) ) {
 
-      if ( line_type( lines[i] ) == false ) {
+      if ( getLineType( lines[i] ) === LINE_TYPE.INVALID ) {
         jQuery("#txt_tuning_data").parent().addClass("has-error");
         return false;
       }

--- a/js/synth.js
+++ b/js/synth.js
@@ -27,7 +27,7 @@ function keycode_to_midinote(keycode) {
   }
 }
 
-function touch_to_midinote( row, col ) {
+function touch_to_midinote({ row, col }) {
   return (row * synth.isomorphicMapping.vertical) + (col * synth.isomorphicMapping.horizontal) + tuning_table['base_midi_note'];
 }
 
@@ -87,16 +87,14 @@ document.addEventListener( "keyup", function(event) {
 jQuery( '#virtual-keyboard' ).on('touchstart', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.targetTouches[0].target).addClass('active');
-  var coord = jQuery( event.target ).data('coord');
-  debug( coord );
-  synth.noteOn( touch_to_midinote( coord[0], coord[1] ) );
+  // debug( coord );
+  synth.noteOn(touch_to_midinote(getCoordsFromKey(event.target)));
 });
 
 // TOUCHEND -- virtual keyboard
 jQuery( '#virtual-keyboard' ).on('touchend', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.changedTouches[0].target).removeClass('active');
-  var coord = jQuery( event.target ).data('coord');
-  debug( coord );
-  synth.noteOff( touch_to_midinote( coord[0], coord[1] ) );
+  // debug( coord );
+  synth.noteOff(touch_to_midinote(getCoordsFromKey(event.target)));
 });

--- a/js/synth.js
+++ b/js/synth.js
@@ -27,8 +27,12 @@ function keycode_to_midinote(keycode) {
   }
 }
 
-function touch_to_midinote({ row, col }) {
-  return (row * synth.isomorphicMapping.vertical) + (col * synth.isomorphicMapping.horizontal) + tuning_table['base_midi_note'];
+function touch_to_midinote([ row, col ]) {
+  if (isNil(row) || isNil(col)) {
+    return false
+  } else {
+    return (row * synth.isomorphicMapping.vertical) + (col * synth.isomorphicMapping.horizontal) + tuning_table['base_midi_note'];
+  }
 }
 
 // is_qwerty_active()

--- a/js/synth.js
+++ b/js/synth.js
@@ -18,7 +18,7 @@ function keycode_to_midinote(keycode) {
   // get row/col vals from the keymap
   var key = synth.keymap[keycode];
 
-  if ( isNil(key) ) {
+  if (isNil(key)) {
     // return false if there is no note assigned to this key
     return false;
   } else {
@@ -27,7 +27,7 @@ function keycode_to_midinote(keycode) {
   }
 }
 
-function touch_to_midinote([ row, col ]) {
+function touch_to_midinote([row, col]) {
   if (isNil(row) || isNil(col)) {
     return false
   } else {
@@ -40,23 +40,23 @@ function touch_to_midinote([ row, col ]) {
 // returns true if focus is in safe area for typing
 // returns false if focus is on an input or textarea element
 function is_qwerty_active() {
-  jQuery( "div#qwerty-indicator" ).empty();
+  jQuery("div#qwerty-indicator").empty();
   var focus = document.activeElement.tagName;
-  if ( focus == 'TEXTAREA' || focus == 'INPUT' ) {
-    jQuery( "div#qwerty-indicator" ).html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-off" aria-hidden="true" style="color:#d9534f"></span> Keyboard disabled</h4><p>Click here to enable QWERTY keyboard playing.</p>');
+  if (focus == 'TEXTAREA' || focus == 'INPUT') {
+    jQuery("div#qwerty-indicator").html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-off" aria-hidden="true" style="color:#d9534f"></span> Keyboard disabled</h4><p>Click here to enable QWERTY keyboard playing.</p>');
     return false;
   }
   else {
-    jQuery( "div#qwerty-indicator" ).html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-down" aria-hidden="true"></span> Keyboard enabled</h4><p>Press QWERTY keys to play current tuning.</p>');
+    jQuery("div#qwerty-indicator").html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-down" aria-hidden="true"></span> Keyboard enabled</h4><p>Press QWERTY keys to play current tuning.</p>');
     return true;
   }
 }
 
 // KEYDOWN -- capture keyboard input
-document.addEventListener( "keydown", function(event) {
+document.addEventListener("keydown", function (event) {
 
   // bail if focus is on an input or textarea element
-  if ( !is_qwerty_active() ) {
+  if (!is_qwerty_active()) {
     return false;
   }
 
@@ -65,40 +65,38 @@ document.addEventListener( "keydown", function(event) {
     return false;
   }
 
-  const midiNote = keycode_to_midinote( event.which ); // midi note number 0-127
+  const midiNote = keycode_to_midinote(event.which); // midi note number 0-127
   const velocity = 100
 
-  if (midiNote !== false)  {
+  if (midiNote !== false) {
     event.preventDefault();
-    synth.noteOn( midiNote, velocity );
+    synth.noteOn(midiNote, velocity);
   }
 });
 
 // KEYUP -- capture keyboard input
-document.addEventListener( "keyup", function(event) {
+document.addEventListener("keyup", function (event) {
   // bail, if a modifier is pressed alongside the key
   if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
     return false;
   }
-  const midiNote = keycode_to_midinote( event.which )
+  const midiNote = keycode_to_midinote(event.which)
   if (midiNote !== false) {
     event.preventDefault();
-    synth.noteOff( midiNote );
+    synth.noteOff(midiNote);
   }
 });
 
 // TOUCHSTART -- virtual keyboard
-jQuery( '#virtual-keyboard' ).on('touchstart', 'td', function (event) {
+jQuery('#virtual-keyboard').on('touchstart', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.targetTouches[0].target).addClass('active');
-  // debug( coord );
-  synth.noteOn(touch_to_midinote(getCoordsFromKey(event.target)));
+  synth.noteOn(tap(debug, touch_to_midinote(getCoordsFromKey(event.target))));
 });
 
 // TOUCHEND -- virtual keyboard
-jQuery( '#virtual-keyboard' ).on('touchend', 'td', function (event) {
+jQuery('#virtual-keyboard').on('touchend', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.changedTouches[0].target).removeClass('active');
-  // debug( coord );
-  synth.noteOff(touch_to_midinote(getCoordsFromKey(event.target)));
+  synth.noteOff(tap(debug, touch_to_midinote(getCoordsFromKey(event.target))));
 });

--- a/js/synth.js
+++ b/js/synth.js
@@ -18,7 +18,7 @@ function keycode_to_midinote(keycode) {
   // get row/col vals from the keymap
   var key = synth.keymap[keycode];
 
-  if (isNil(key)) {
+  if ( isNil(key) ) {
     // return false if there is no note assigned to this key
     return false;
   } else {
@@ -27,7 +27,7 @@ function keycode_to_midinote(keycode) {
   }
 }
 
-function touch_to_midinote([row, col]) {
+function touch_to_midinote([ row, col ]) {
   if (isNil(row) || isNil(col)) {
     return false
   } else {
@@ -40,23 +40,23 @@ function touch_to_midinote([row, col]) {
 // returns true if focus is in safe area for typing
 // returns false if focus is on an input or textarea element
 function is_qwerty_active() {
-  jQuery("div#qwerty-indicator").empty();
+  jQuery( "div#qwerty-indicator" ).empty();
   var focus = document.activeElement.tagName;
-  if (focus == 'TEXTAREA' || focus == 'INPUT') {
-    jQuery("div#qwerty-indicator").html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-off" aria-hidden="true" style="color:#d9534f"></span> Keyboard disabled</h4><p>Click here to enable QWERTY keyboard playing.</p>');
+  if ( focus == 'TEXTAREA' || focus == 'INPUT' ) {
+    jQuery( "div#qwerty-indicator" ).html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-off" aria-hidden="true" style="color:#d9534f"></span> Keyboard disabled</h4><p>Click here to enable QWERTY keyboard playing.</p>');
     return false;
   }
   else {
-    jQuery("div#qwerty-indicator").html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-down" aria-hidden="true"></span> Keyboard enabled</h4><p>Press QWERTY keys to play current tuning.</p>');
+    jQuery( "div#qwerty-indicator" ).html('<img src="" style="float:right" /><h4><span class="glyphicon glyphicon glyphicon-volume-down" aria-hidden="true"></span> Keyboard enabled</h4><p>Press QWERTY keys to play current tuning.</p>');
     return true;
   }
 }
 
 // KEYDOWN -- capture keyboard input
-document.addEventListener("keydown", function (event) {
+document.addEventListener( "keydown", function(event) {
 
   // bail if focus is on an input or textarea element
-  if (!is_qwerty_active()) {
+  if ( !is_qwerty_active() ) {
     return false;
   }
 
@@ -65,37 +65,37 @@ document.addEventListener("keydown", function (event) {
     return false;
   }
 
-  const midiNote = keycode_to_midinote(event.which); // midi note number 0-127
+  const midiNote = keycode_to_midinote( event.which ); // midi note number 0-127
   const velocity = 100
 
-  if (midiNote !== false) {
+  if (midiNote !== false)  {
     event.preventDefault();
-    synth.noteOn(midiNote, velocity);
+    synth.noteOn( midiNote, velocity );
   }
 });
 
 // KEYUP -- capture keyboard input
-document.addEventListener("keyup", function (event) {
+document.addEventListener( "keyup", function(event) {
   // bail, if a modifier is pressed alongside the key
   if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
     return false;
   }
-  const midiNote = keycode_to_midinote(event.which)
+  const midiNote = keycode_to_midinote( event.which )
   if (midiNote !== false) {
     event.preventDefault();
-    synth.noteOff(midiNote);
+    synth.noteOff( midiNote );
   }
 });
 
 // TOUCHSTART -- virtual keyboard
-jQuery('#virtual-keyboard').on('touchstart', 'td', function (event) {
+jQuery( '#virtual-keyboard' ).on('touchstart', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.targetTouches[0].target).addClass('active');
   synth.noteOn(tap(debug, touch_to_midinote(getCoordsFromKey(event.target))));
 });
 
 // TOUCHEND -- virtual keyboard
-jQuery('#virtual-keyboard').on('touchend', 'td', function (event) {
+jQuery( '#virtual-keyboard' ).on('touchend', 'td', function (event) {
   event.preventDefault();
   jQuery(event.originalEvent.changedTouches[0].target).removeClass('active');
   synth.noteOff(tap(debug, touch_to_midinote(getCoordsFromKey(event.target))));

--- a/js/ui.js
+++ b/js/ui.js
@@ -31,12 +31,9 @@ function touch_kbd_open() {
   }
 
   // display tuning info on virtual keys
-  jQuery('#virtual-keyboard td' ).each( function(index) {
-
+  jQuery('#virtual-keyboard td').each( function() {
     // get the coord data attribute and figure out the midinote
-    var row = eval( jQuery(this).attr('data-coord') )[0];
-    var col = eval( jQuery(this).attr('data-coord') )[1];
-    var midinote = touch_to_midinote( row, col );
+    const midinote = touch_to_midinote(getCoordsFromKey(this));
 
     // add text to key
     //jQuery(this).append("<p><small>midi</small> <strong>" + midinote + "</strong></p>");


### PR DESCRIPTION
Hi!

I've removed the eval calls from the code and added a few helper functions for validating lines. I've also added constants.js, where global constants and enums can be added.

If the camel case doesn't work for you, then I can change my functions to be dash case.

With this addition lines like `240.;alert('hello')` are no longer valid cents and XSS can no longer be done.

http://sevish.com/scaleworkshop-dev/?name=5%20equal%20divisions%20of%202%2F1&data=240.%3Balert(%27Hello%27)%0A480.%0A720.%0A960.%0A1200.&freq=440&midi=69&vert=5&horiz=1&colors=white%20black%20white%20white%20black%20white%20black%20white%20white%20black%20white%20black&waveform=triangle&ampenv=organ