### PR TITLE
Methods for faster MOS size generation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -376,7 +376,7 @@
         </div>
       </form>
       <hr/>
-      <button class="btn btn-default" onclick="show_mos( jQuery('#input_rank-2_period').val(), jQuery('#input_rank-2_generator').val(), jQuery('#input_rank-2_size').val(), jQuery('#input_rank-2_mos_threshold').val() );" style="float:left;">Show MOS</button>
+      <button class="btn btn-default" onclick="show_mos_cf( jQuery('#input_rank-2_period').val(), jQuery('#input_rank-2_generator').val(), jQuery('#input_rank-2_size').val(), jQuery('#input_rank-2_mos_threshold').val() );" style="float:left;">Show MOS</button>
       <p style="text-align:right;">(ignore MOS with steps smaller than <input id="input_rank-2_mos_threshold" name="" type="number" min="0.1" max="600" value="2.5" style="width:4em;"></input> cents)</p>
       <span id="info_rank_2_mos" style="display:block;margin-top:10px;"></span>
     </div>


### PR DESCRIPTION
I added some methods using continued fractions to generate MOS period sizes. This can be used as the basis for other features too.

The "get_convergents" function can generate rational approximations to any real number. 

This most obvious feature here would be to take a scale with irrational intervals and make one with rational approximations. Users could decide between having high limits ratios to minimize the deviation from the original scale, or having lower limit ratios which will have higher deviation with (potentially) nicer sounding intervals.

Along with finding the MOS period size, it gives you the step of that period which approximates the given generator. For example, with g=(3/2), p=(2/1), it will give the fractions:

1/2, 2/3, 3/5, 4/7, 7/12, 10/17, 17/29, 24/41, 31/53, 55/94, 86/147 ...

Which is g/p.