### PR TITLE
Continued Fraction based MOS size generation

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -376,7 +376,7 @@
         </div>
       </form>
       <hr/>
-      <button class="btn btn-default" onclick="show_mos( jQuery('#input_rank-2_period').val(), jQuery('#input_rank-2_generator').val(), jQuery('#input_rank-2_size').val(), jQuery('#input_rank-2_mos_threshold').val() );" style="float:left;">Show MOS</button>
+      <button class="btn btn-default" onclick="show_mos_cf( jQuery('#input_rank-2_period').val(), jQuery('#input_rank-2_generator').val(), jQuery('#input_rank-2_size').val(), jQuery('#input_rank-2_mos_threshold').val() );" style="float:left;">Show MOS</button>
       <p style="text-align:right;">(ignore MOS with steps smaller than <input id="input_rank-2_mos_threshold" name="" type="number" min="0.1" max="600" value="2.5" style="width:4em;"></input> cents)</p>
       <span id="info_rank_2_mos" style="display:block;margin-top:10px;"></span>
     </div>

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -318,14 +318,14 @@ function show_mos_cf(per, gen, ssz, threshold) {
         c = L - s;
         
         // break if g is some equal division of period
-        if (c < 1 / roundf && cf.length < maxcfsize)
+        if (c < (1 / roundf) && cf.length < maxcfsize)
         {
-          // add size-1 if the degree of the period is
-          // greater than period +/- 1.
-          // ex: true if 3\17 or 5\17, false if 1\17 or 16\17.
+          // add size-1 
           // not sure if flaw in the algorithm or weird edge case
-          if (cf.length > 3)
-            dd.splice(dd.length-1, 0, dd[dd.length-1]-1)
+          
+          if (dd[dd.length-2] != dd[dd.length-1]-1)
+            dd.splice(dd.length-1, 0, dd[dd.length-1]-1);
+
           break;
         }
         


### PR DESCRIPTION
A faster algorithm for generating MOS sizes that can also lend to some other potential features such as getting rational approximations for irrational intervals.

In my testing, it produces identical results to the previous algorithm.

There is one workaround for an edge case where generators that are of an equal division to the period don't produce the proper penultimate MOS size (which is, in this case, is always the last size - 1).