### PR TITLE
fix: main volume can now be set for the Synth before initializing it

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -336,9 +336,7 @@ jQuery( document ).ready( function() {
   // Synth Settings - Main Volume
   jQuery(document).on('input', '#input_range_main_vol', function() {
     const gain = jQuery(this).val();
-    const now = synth.now();
-    synth.masterGain.gain.value = gain;
-    synth.masterGain.gain.setValueAtTime(gain, now);
+    synth.setMainVolume(gain)
   });
 
 

--- a/js/synth/Synth.js
+++ b/js/synth/Synth.js
@@ -7,6 +7,7 @@ class Synth {
     }
     this.active_voices = {} // polyphonic voice management
     this.waveform = 'triangle'
+    this.mainVolume = 0.8
     this.inited = false
 
     this.delay = new Delay(this)
@@ -19,7 +20,7 @@ class Synth {
 
       // master gain
       this.masterGain = this.audioCtx.createGain(); // create master gain before output
-      this.masterGain.gain.value = 0.8;
+      this.masterGain.gain.value = this.mainVolume;
       // master filter
       this.masterLPfilter = this.audioCtx.createBiquadFilter();
       this.masterLPfilter.frequency.value = 5000;
@@ -30,6 +31,18 @@ class Synth {
       this.masterLPfilter.connect( this.audioCtx.destination );
 
       this.delay.init(this.audioCtx)
+    }
+  }
+
+  setMainVolume(newValue) {
+    const oldValue = this.mainVolume
+    if (newValue !== oldValue) {
+      this.mainVolume = newValue
+      if (this.inited) {
+        const now = this.now();
+        this.masterGain.gain.value = newValue;
+        this.masterGain.gain.setValueAtTime(newValue, now);
+      }
     }
   }
 


### PR DESCRIPTION
An error is thrown when you change the main volume before initializing the webaudio api. (webaudio is initialized by pressing a key on the keyboard in a JIT manner)