### PR TITLE
Enumerate chords

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -77,6 +77,7 @@
                 <li><a href="#" id="generate_rank_2_temperament"><span class="glyphicon glyphicon-stats" aria-hidden="true"></span> Rank-2 temperament</a></li>
                 <li><a href="#" id="generate_harmonic_series_segment"><span class="glyphicon glyphicon-stats" aria-hidden="true"></span> Harmonic series segment</a></li>
                 <li><a href="#" id="generate_subharmonic_series_segment"><span class="glyphicon glyphicon-stats" aria-hidden="true"></span> Subharmonic series segment</a></li>
+                <li><a href="#" id="enumerate_chord"><span class="glyphicon glyphicon-stats" aria-hidden="true"></span> Enumerate chord</a></li>
                 <li class="divider"></li>
                 <li><a href="#" id="import-scala-scl"><span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Import .scl</a></li>
                 <li><a href="#" id="import-anamark-tun"><span class="glyphicon glyphicon-log-in" aria-hidden="true"></span> Import .tun</a></li>
@@ -405,6 +406,15 @@
         <label>Highest subharmonic</label>
         <div class="form-group">
           <input id="input_highest_subharmonic" name="" type="number" min="1" max="999999" step="1" class="form-control" value="16"></input>
+        </div>
+      </form>
+    </div>
+
+    <div id="modal_enumerate_chord" class="modal" title="Enumerate chord">
+      <form>
+        <label>Chord</label>
+        <div class="form-group">
+          <input id="input_chord" name="" type="text" class="form-control" value="4:5:6:7"></input>
         </div>
       </form>
     </div>

--- a/index.htm
+++ b/index.htm
@@ -416,6 +416,9 @@
         <div class="form-group">
           <input id="input_chord" name="" type="text" class="form-control" value="4:5:6:7"></input>
         </div>
+        <label>
+            <input id="input_preserve_cents" type="checkbox" checked="checked"></input> Preserve cents values
+        </label>
       </form>
     </div>
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,5 +1,6 @@
 const LINE_TYPE = {
   CENTS: 'cents',
+  DECIMAL: 'decimal',
   RATIO: 'ratio',
   N_OF_EDO: 'n of edo',
   INVALID: 'invalid'

--- a/js/events.js
+++ b/js/events.js
@@ -169,6 +169,25 @@ jQuery( document ).ready( function() {
 
   } );
 
+// enumerate_chord option clicked
+  jQuery( "#enumerate_chord" ).click( function( event ) {
+
+    event.preventDefault();
+    jQuery( "#input_chord" ).select();
+    jQuery( "#modal_enumerate_chord" ).dialog({
+      modal: true,
+      buttons: {
+        OK: function() {
+          enumerate_chord();
+        },
+        Cancel: function() {
+          jQuery( this ).dialog( 'close' );
+        }
+      }
+    });
+
+  } );
+
   // load-preset option clicked
   jQuery( "#load-preset" ).click( function( event ) {
 

--- a/js/generators.js
+++ b/js/generators.js
@@ -222,21 +222,36 @@ function generate_subharmonic_series_segment_data(lo, hi) {
 
 function enumerate_chord() {
 
-  var chord = getString('#input_chord', 'Warning: bad input')
+  var chord = getString('#input_chord', 'Warning: bad input');
+  var preserve_cents = document.getElementById( "input_preserve_cents" ).checked;
+
+  // It doesn't make much sense to mix different values, 
+  // but it's cool to experiment with.
 
   // bail if has invalid characters
-  var inputTest = chord.replace(" ", "");
+  var inputTest = chord.replace(" ", "").split();
   for (var i = 0; i < inputTest.length; i++) {
-  	  var c = inputTest.charCodeAt(i);
-	  if ((c < 46 && c != 44) || c > 58) {
-		alert("Warning: Invalid pitch data.")
+	  if (/^\d+[\.\,\\\/]*\d*$/.test(inputTest[i])) {
+		alert("Warning: Invalid pitch" + inputTest[i])
 		return false;
 	  }
   }
 
+  var pitches = chord.split(":");
+
+  // This next safeguard might make it more user friendy,
+  // but I think it's a bit limiting for certain purposes a more advanced
+  // user might try like using NOfEdo values to build chords.
+
+  // bail if first note is in cents
+  //if (isCent(pitches[0]) || isNOfEdo(pitches[0])) {
+  //	  alert("Warning: first pitch cannot be in cents");
+  //  return false;
+  //}
+
   setScaleName("Chord " + chord);
 
-  setTuningData(enumerate_chord_data(chord.split(":")));
+  setTuningData(enumerate_chord_data(pitches, preserve_cents));
 
   parse_tuning_data();
 
@@ -246,7 +261,7 @@ function enumerate_chord() {
   return true;
 }
 
-function enumerate_chord_data(pitches) {
+function enumerate_chord_data(pitches, preserveCents=true) {
   let ratios = [];
   var fundamental = 1;
 
@@ -258,10 +273,15 @@ function enumerate_chord_data(pitches) {
 		pitches[i] = pitches[i] + ',';
 	}
 
+	var isCentsValue = isCent(pitches[i]) || isNOfEdo(pitches[i]);
     var parsed = line_to_decimal(pitches[i]);
 
     if (i > 0) {
-      ratios.push(decimal_to_ratio(parsed / fundamental));
+	  if (isCentsValue && preserveCents) {
+	  	ratios.push(pitches[i])
+	  } else {
+		ratios.push(decimal_to_ratio(parsed / fundamental));
+	  }
     }
     else {
       fundamental = parsed;

--- a/js/generators.js
+++ b/js/generators.js
@@ -220,6 +220,57 @@ function generate_subharmonic_series_segment_data(lo, hi) {
   return ratios.join(unix_newline)
 }
 
+function enumerate_chord() {
+
+  var chord = getString('#input_chord', 'Warning: bad input')
+
+  // bail if has invalid characters
+  var inputTest = chord.replace(" ", "");
+  for (var i = 0; i < inputTest.length; i++) {
+  	  var c = inputTest.charCodeAt(i);
+	  if ((c < 46 && c != 44) || c > 58) {
+		alert("Warning: Invalid pitch data.")
+		return false;
+	  }
+  }
+
+  setScaleName("Chord " + chord);
+
+  setTuningData(enumerate_chord_data(chord.split(":")));
+
+  parse_tuning_data();
+
+  closePopup("#modal_enumerate_chord");
+
+  // success
+  return true;
+}
+
+function enumerate_chord_data(pitches) {
+  let ratios = [];
+  var fundamental = 1;
+
+  for (var i = 0; i < pitches.length; i++) {
+    
+	// convert a lone integer to a commadecimal
+	if (/^\d+$/.test(pitches[i]))
+	{
+		pitches[i] = pitches[i] + ',';
+	}
+
+    var parsed = line_to_decimal(pitches[i]);
+
+    if (i > 0) {
+      ratios.push(decimal_to_ratio(parsed / fundamental));
+    }
+    else {
+      fundamental = parsed;
+    }
+  }
+
+  return ratios.join(unix_newline)
+}
+
 function load_preset_scale(a) {
 
   var data = "";

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -223,14 +223,14 @@ function sum_array(array, index)
 }
       
 // calculate a continued fraction for the given number
-function get_cf(num, sizelimit, roundf) {
+function get_cf(num, maxiterations, roundf) {
     var cf = [] // the continued fraction
     var digit;
     
     var roundinv = 1.0 / roundf;
     
     var iterations = 0;
-    while (iterations < sizelimit)
+    while (iterations < maxiterations)
     {
         digit = Math.floor(num);
         cf.push(digit);
@@ -247,6 +247,53 @@ function get_cf(num, sizelimit, roundf) {
     }
 
     return cf;
+}
+
+// calculate a single convergent for a given continued fraction
+function get_convergent(cf, depth=0) {
+
+    var cfdigit; // the continued fraction digit
+    var num; // the convergent numerator
+    var den; // the convergent denominator
+    var tmp; // for easy reciprocation
+
+	if (depth >= cf.length || depth == 0)
+		depth = cf.length;
+    
+    for (var d = 0; d < depth; d++)
+    {
+        cfdigit = cf[d];
+        num = cfdigit;
+        den = 1;
+        
+        // calculate the convergent
+        for (var i = d; i > 0; i--)
+        {
+            tmp = den;
+            den = num;
+            num = tmp;
+            num += den * cf[i - 1];
+        }
+    }
+
+	return num + '/' + den;
+}
+
+// convert a decimal to ratio (string 'x/y'), may have rounding errors for irrationals
+function decimal_to_ratio(rawInput, iterations=15, depth=0) {
+
+	if (rawInput === false)
+		return false;
+	
+	const input = parseFloat(line_to_decimal(rawInput));
+	
+	if (input === 0 || isNaN(input)) {
+		return false;
+    } 
+	else {
+		var inputcf = get_cf(input, iterations, 100000);
+		return get_convergent(inputcf, depth);
+	}
 }
 
 // calculate rational approximations given a continued fraction

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -25,6 +25,19 @@ function ratio_to_decimal(rawInput) {
   }
 }
 
+// convert a comma decimal (1,25) to decimal
+function commadecimal_to_decimal(rawInput) {
+  if (rawInput === false) {
+    return false
+  }
+  const input = parseFloat(rawInput.toString().replace(',', '.'));
+  if (input === 0 || isNaN(input)) {
+    return false;
+  } else {
+    return input;
+  }
+}
+
 function decimal_to_cents(rawInput) {
   if (rawInput === false) {
     return false
@@ -66,6 +79,13 @@ function isCent(rawInput) {
   return /^\d+\.\d*$/.test(input)
 }
 
+function isDecimal(rawInput) {
+  // true, when the input has numbers at the beginning, followed by a comma, ending with any number of numbers
+  // for example: 1,25
+  const input = trim(toString(rawInput))
+  return /^\d+\,\d*$/.test(input);
+}
+
 function isNOfEdo(rawInput) {
   // true, when the input has numbers at the beginning and the end, separated by a single backslash
   // for example: 7\12
@@ -83,6 +103,8 @@ function isRatio(rawInput) {
 function getLineType(rawInput) {
   if (isCent(rawInput)) {
     return LINE_TYPE.CENTS
+  } else if (isDecimal(rawInput)) {
+    return LINE_TYPE.DECIMAL
   } else if (isNOfEdo(rawInput)) {
     return LINE_TYPE.N_OF_EDO
   } else if (isRatio(rawInput)) {
@@ -100,6 +122,9 @@ function line_to_decimal(rawInput) {
     case LINE_TYPE.CENTS:
       converterFn = cents_to_decimal
       break
+	case LINE_TYPE.DECIMAL:
+	  converterFn = commadecimal_to_decimal
+	  break
     case LINE_TYPE.N_OF_EDO:
       converterFn = n_of_edo_to_decimal
       break

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -27,15 +27,28 @@ function ratio_to_decimal(rawInput) {
 
 // convert a comma decimal (1,25) to decimal
 function commadecimal_to_decimal(rawInput) {
-  if (rawInput === false) {
-    return false
-  }
-  const input = parseFloat(rawInput.toString().replace(',', '.'));
-  if (input === 0 || isNaN(input)) {
-    return false;
+  if (isCommaDecimal(rawInput)) {
+    const input = parseFloat(rawInput.toString().replace(',', '.'));
+    if (input === 0 || isNaN(input)) {
+      return false;
+    } else {
+      return input;
+	}
   } else {
-    return input;
+  	alert("Invalid input: " + rawInput);
+	return false;
   }
+}
+
+// convert a decimal (1.25) into commadecimal (1,25)
+function decimal_to_commadecimal(rawInput) {
+	if (isCents(rawInput)) { // a bit misleading
+		const input = rawInput.toString().replace('.', ',');
+		return input;
+	} else {
+		alert("Invalid input: " + rawInput);
+		return false;
+	}
 }
 
 function decimal_to_cents(rawInput) {
@@ -79,7 +92,7 @@ function isCent(rawInput) {
   return /^\d+\.\d*$/.test(input)
 }
 
-function isDecimal(rawInput) {
+function isCommaDecimal(rawInput) {
   // true, when the input has numbers at the beginning, followed by a comma, ending with any number of numbers
   // for example: 1,25
   const input = trim(toString(rawInput))
@@ -103,7 +116,7 @@ function isRatio(rawInput) {
 function getLineType(rawInput) {
   if (isCent(rawInput)) {
     return LINE_TYPE.CENTS
-  } else if (isDecimal(rawInput)) {
+  } else if (isCommaDecimal(rawInput)) {
     return LINE_TYPE.DECIMAL
   } else if (isNOfEdo(rawInput)) {
     return LINE_TYPE.N_OF_EDO
@@ -285,7 +298,7 @@ function decimal_to_ratio(rawInput, iterations=15, depth=0) {
 	if (rawInput === false)
 		return false;
 	
-	const input = parseFloat(line_to_decimal(rawInput));
+	const input = parseFloat(rawInput);
 	
 	if (input === 0 || isNaN(input)) {
 		return false;
@@ -294,6 +307,14 @@ function decimal_to_ratio(rawInput, iterations=15, depth=0) {
 		var inputcf = get_cf(input, iterations, 100000);
 		return get_convergent(inputcf, depth);
 	}
+}
+
+function cents_to_ratio(rawInput, iterations=15, depth=0) {
+	return decimal_to_ratio(cents_to_decimal(rawInput), iterations, depth);
+}
+
+function n_of_edo_to_ratio(rawInput, iterations=15, depth=0) {
+	return decimal_to_ratio(n_of_edo_to_decimal(rawInput), iterations, depth);
 }
 
 // calculate rational approximations given a continued fraction


### PR DESCRIPTION
This adds an "Enumerate Chord" feature that allows an input such as "4:5:6:7" to be parsed into a "scale" such as "5/4, 3/2, 7/4". You can mix in decimals, commas, and NOfEdos, where the latter two are rooted in unison.
I find this to be a much quicker and easier way to try out just intonation chords compared to other online tools. 