### PR TITLE
Added a "MOS Mode" option added "Rotation" buttons to the Mode feature

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
   ____            _
  / ___|  ___ __ _| | ___
  \___ \ / __/ _` | |/ _ \
@@ -487,31 +487,32 @@
       <form>
         <label>Mode</label>
         <div class="form-group">
-          <input id="input_modify_mode" name="" type="text" class="form-control" value="" placeholder="2 2 1 2 2 2 1"></input>
-          <div class="radio">
-            <label><input type="radio" name="mode_type" value="intervals" checked>Intervals (e.g. 2 2 1 2 2 2 1)</label>
-          </div>
-          <div class="radio">
-            <label><input type="radio" name="mode_type" value="frombase">From base note (e.g. 2 4 5 7 9 11 12)</label>
-          </div>
-          <div class="radio">
-            <label><input type="radio" name="mode_type" value="mos">MOS Mode (select a degree to stack)</label>
-          </div>
-          <div id="mos_mode_options">
-           <div class="form-row">
-            <div class="form-group col-md-6">
-              <label> Degree </label>
-              <select class="form-control" id="modal_modify_mos_degree"></select>
+            <input id="input_modify_mode" name="" type="text" class="form-control" value="" placeholder="2 2 1 2 2 2 1"></input>
+            <div class="form-row">
+                <button class="btn btn-default" id="input_mode_step_left" type="button">&laquo</button>
+                <button class="btn btn-default" id="input_mode_step_right" type="button">&raquo</button>
             </div>
-            <div class="form-group col-md-6">
-              <label> Size </label>
-              <select class="form-control" id="modal_modify_mos_size"></select>
+            <div class="radio">
+                <label><input type="radio" name="mode_type" value="intervals" checked>Intervals (e.g. 2 2 1 2 2 2 1)</label>
             </div>
-           </div>
-           <div class="form-row">
-               <label>Rotation</label> <input id="modal_modify_mos_rotation" type="number" min="-400" max="400" value="0">
-           </div>
-          </div>
+            <div class="radio">
+                <label><input type="radio" name="mode_type" value="frombase">From base note (e.g. 2 4 5 7 9 11 12)</label>
+            </div>
+            <div class="radio">
+                <label><input type="radio" name="mode_type" value="mos">MOS Mode (select a degree to stack)</label>
+            </div>
+            <div id="mos_mode_options">
+                <div class="form-row">
+                    <div class="form-group col-md-6">
+                        <label> Degree </label>
+                        <select class="form-control" id="modal_modify_mos_degree"></select>
+                    </div>
+                    <div class="form-group col-md-6">
+                        <label> Size </label>
+                        <select class="form-control" id="modal_modify_mos_size"></select>
+                    </div>
+                </div>
+            </div>
         </div>
       </form>
     </div>

--- a/index.htm
+++ b/index.htm
@@ -1,4 +1,4 @@
-﻿<!--
+<!--
   ____            _
  / ___|  ___ __ _| | ___
  \___ \ / __/ _` | |/ _ \
@@ -493,6 +493,24 @@
           </div>
           <div class="radio">
             <label><input type="radio" name="mode_type" value="frombase">From base note (e.g. 2 4 5 7 9 11 12)</label>
+          </div>
+          <div class="radio">
+            <label><input type="radio" name="mode_type" value="mos">MOS Mode (select a degree to stack)</label>
+          </div>
+          <div id="mos_mode_options">
+           <div class="form-row">
+            <div class="form-group col-md-6">
+              <label> Degree </label>
+              <select class="form-control" id="modal_modify_mos_degree"></select>
+            </div>
+            <div class="form-group col-md-6">
+              <label> Size </label>
+              <select class="form-control" id="modal_modify_mos_size"></select>
+            </div>
+           </div>
+           <div class="form-row">
+               <label>Rotation</label> <input id="modal_modify_mos_rotation" type="number" min="-400" max="400" value="0">
+           </div>
           </div>
         </div>
       </form>

--- a/js/events.js
+++ b/js/events.js
@@ -214,6 +214,8 @@ jQuery( document ).ready( function() {
     // setup MOS options, and hide
     update_modify_mode_mos_generators();
     show_modify_mode_mos_options(document.querySelector('input[name="mode_type"]:checked').value);
+	jQuery( "#modal_modify_mos_degree").change(); // make sizes available
+
     jQuery( "#input_modify_mode" ).select();
     jQuery( "#modal_modify_mode" ).dialog({
       modal: true,
@@ -435,10 +437,7 @@ jQuery( document ).ready( function() {
          var p = tuning_table.note_count-1;
          var g = parseInt($("#modal_modify_mos_degree").val());
          var s = parseInt($("#modal_modify_mos_size").val());
-         var r = parseInt($("#modal_modify_mos_rotation").val());
-        console.log(p +", "+ g+", " + s+", " + r)
-         let mode = get_rank2_mode(p, g, s, 0);
-	 rotate(mode, r);
+         let mode = get_rank2_mode(p, g, s);
          $("#input_modify_mode").val(mode.join(" "));
      }
     
@@ -458,8 +457,16 @@ jQuery( document ).ready( function() {
         modify_mode_update_mos_scale();
     })
                          
-     jQuery( "#modal_modify_mos_rotation").change( function() {
-        modify_mode_update_mos_scale();
+     jQuery( "#input_mode_step_left").click( function() {
+		var mode = jQuery( "#input_modify_mode" ).val().split(" ");
+		rotate(mode, -1);
+		jQuery( "#input_modify_mode" ).val(mode.join(" "));
+     })
+
+	 jQuery( "#input_mode_step_right").click( function() {
+		var mode = jQuery( "#input_modify_mode" ).val().split(" ");
+		rotate(mode, 1);
+		jQuery( "#input_modify_mode" ).val(mode.join(" "));
      })
                         
   /*

--- a/js/events.js
+++ b/js/events.js
@@ -211,6 +211,9 @@ jQuery( document ).ready( function() {
   jQuery( "#modify_mode" ).click( function( event ) {
 
     event.preventDefault();
+    // setup MOS options, and hide
+    update_modify_mode_mos_generators();
+    show_modify_mode_mos_options(document.querySelector('input[name="mode_type"]:checked').value);
     jQuery( "#input_modify_mode" ).select();
     jQuery( "#modal_modify_mode" ).dialog({
       modal: true,
@@ -407,6 +410,56 @@ jQuery( document ).ready( function() {
     jQuery( "#input_approx_max_prime").val(PRIMES[prime_counter[1]]);
     modify_update_approximations();
   })
+                                                
+    // shows or hides MOS mode selection boxes
+    function show_modify_mode_mos_options(showOptions) {
+      document.getElementById("mos_mode_options").style.display = showOptions == "mos" ?  'block' : 'none';
+    }
+                         
+    jQuery( "#modal_modify_mode").change( function() {
+        show_modify_mode_mos_options(document.querySelector('input[name="mode_type"]:checked').value)
+    })
+
+    function update_modify_mode_mos_generators() {
+        show_modify_mode_mos_options(document.querySelector('input[name="mode_type"]:checked').value)
+        let coprimes = get_coprimes(tuning_table.note_count-1);
+        $("#modal_modify_mos_degree").empty();
+        for (var d=1; d < coprimes.length-1; d++) {
+            var num = coprimes[d];
+           $("#modal_modify_mos_degree").append('<option value="'+num+'">'+num+'</option>');
+        }
+                                            
+     }
+    
+     function modify_mode_update_mos_scale() {
+         var p = tuning_table.note_count-1;
+         var g = parseInt($("#modal_modify_mos_degree").val());
+         var s = parseInt($("#modal_modify_mos_size").val());
+         var r = parseInt($("#modal_modify_mos_rotation").val());
+        console.log(p +", "+ g+", " + s+", " + r)
+         let mode = get_rank2_mode(p, g, s, r);
+         $("#input_modify_mode").val(mode.join(" "));
+     }
+    
+    jQuery( "#modal_modify_mos_degree").change( function() {
+        let nn = [];
+        let dd = [];
+        var gp = jQuery("#modal_modify_mos_degree").val() / (tuning_table.note_count-1);
+        get_rational_approximations(gp, nn, dd);
+        $("#modal_modify_mos_size").empty();
+        for (var d=2; d < dd.length-1; d++) {
+           var num = dd[d];
+           $("#modal_modify_mos_size").append('<option value="'+num+'">'+num+'</option>');
+        }
+    })
+                         
+    jQuery( "#modal_modify_mos_size").change( function() {
+        modify_mode_update_mos_scale();
+    })
+                         
+     jQuery( "#modal_modify_mos_rotation").change( function() {
+        modify_mode_update_mos_scale();
+     })
                         
   /*
     // rank-2 temperament generator - scale size changed

--- a/js/events.js
+++ b/js/events.js
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * EVENT HANDLERS AND OTHER DOCUMENT READY STUFF
  */
 
@@ -437,7 +437,8 @@ jQuery( document ).ready( function() {
          var s = parseInt($("#modal_modify_mos_size").val());
          var r = parseInt($("#modal_modify_mos_rotation").val());
         console.log(p +", "+ g+", " + s+", " + r)
-         let mode = get_rank2_mode(p, g, s, r);
+         let mode = get_rank2_mode(p, g, s, 0);
+	 rotate(mode, r);
          $("#input_modify_mode").val(mode.join(" "));
      }
     

--- a/js/generators.js
+++ b/js/generators.js
@@ -22,7 +22,8 @@ function generate_equal_temperament() {
   parse_tuning_data();
 
   closePopup('#modal_generate_equal_temperament')
-
+	
+	generate_mos_modes_test(divider);
   // success
   return true;
 }

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -497,7 +497,7 @@ function get_rank2_mode(period, generator, size, numdown=0) {
 		if (interval >= period) {
 			interval %= period;
 		}
-
+        console.log('pusshing ' + interval);
 		degrees.push(interval);
 	}
 
@@ -636,44 +636,25 @@ function get_prime_limit(number) {
     return Math.max(get_prime_limit(numerator), get_prime_limit(denominator));
  }
 
- function isLinearlyIndependent(arrayOfVectors) {
-	var hasnext = true;
-	var isIndependent = true;
-	var i = 0;
-	while(hasnext) {
-		hasnext = false;
-		var sum = 0;
-		for (var v = 0; v < arrayOfVectors.length; v++) {
-			let vector = arrayOfVectors[v];
-			if (i < vector.length) {
-				if (i < vector.length - 1)
-					hasnext = true;
-				if (vector[i] > 0)
-					sum += 1;
-			}
-		}
-		if (sum > 1) {
-			isIndependent = false;
-			break;
-		}
-		i++;
-	}
-	return isIndependent;
- }
-
  // returns an array of integers that share no common factors to the given integer
-  function get_coprimes(number) {
- 	 let coprimes = [1];
-	 var numpf = get_prime_factors(number);
-
-	  // not sure if a recursive based method would be more efficent
-	 for (var n = 2; n < number; n++) {
-	 	 var iscoprime = isLinearlyIndependent([numpf, get_prime_factors(n)]);
-		 if (iscoprime)
-			coprimes.push(n);
-	 }
-	 
-	 return coprimes;
+ function get_coprimes(number) {
+    let coprimes = [1];
+    var m, d, t;
+    for (var i = 2; i < number - 1; i++) {
+        m = number;
+        d = i;
+        while (d > 1) {
+            m = m % d;
+            t = d;
+            d = m;
+            m = t;
+        }
+        if (d > 0) {
+            coprimes.push(i);
+        }
+    }
+    coprimes.push(number-1);
+    return coprimes;
  }
 
  // returns an array of integers that can divide evenly into given number

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -514,7 +514,6 @@ function get_rank2_mode(period, generator, size, numdown=0) {
 		if (interval >= period) {
 			interval %= period;
 		}
-        console.log('pusshing ' + interval);
 		degrees.push(interval);
 	}
 

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -792,33 +792,6 @@ function get_prime_limit(number) {
 	return chord.join(":");
  }
 
- function generate_mos_modes_test(period)
- {
-	var sizefactors = get_factors(period);
-	sizefactors.push(period);
-	debug("Printing all modes of size " + period + " and its factors\' modes:" + sizefactors.join(" "));
-	for (var f = 0; f < sizefactors.length; f++) {
-	var cp = get_coprimes(sizefactors[f]);
-		for (var i = 0; i < cp.length; i++) {
-			var nn = [];
-			var dd = [];
-			var cind = [];
-			get_rational_approximations(cp[i] / sizefactors[f], nn, dd, 99999, cind);
-			debug(cp[i]+"\\"+sizefactors[f]+" modes, with mos sizes of: " + dd.join(" "));
-			var ll = true ? dd.length : cind.length;
-			for (var m = 1; m < ll; m++) {
-				var ddd = ll == dd.length ? dd[m] : dd[cind[m]];
-				var mode = get_rank2_mode(sizefactors[f], cp[i], ddd);
-				var factor = period / sizefactors[f];
-				mode.forEach(function(item, index) {
-					mode[index] = item * factor;
-				});
-				debug(sizefactors[f]+" | "+cp[i]+" | "+ddd+"\t: " + mode.join(" "));
-			}
-		}
-	}
- }
-
 function debug(msg = "") {
   if (debug_enabled) {
     msg = isEmpty(msg) ? "Debug" : msg;

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -235,6 +235,23 @@ function sum_array(array, index)
 
     return sum;
 }
+
+// rotates the array by given steps
+function rotate(array, steps)
+{
+    var i = Math.abs(steps);
+    while (i > 0) {
+	var x;
+        if (steps < 0) {
+            x = array.shift();
+	    array.push(x);
+	} else if (steps > 0) {
+	    x = array.pop();
+	    array.unshift(x);
+	}
+	i--;
+    }
+} 
       
 // calculate a continued fraction for the given number
 function get_cf(num, maxiterations, roundf) {

--- a/js/modifiers.js
+++ b/js/modifiers.js
@@ -146,7 +146,7 @@ function modify_mode() {
   // mode_type will be either intervals (e.g. 2 2 1 2 2 2 1) or from_base (e.g. 2 4 5 7 9 11 12)
   var mode_type = jQuery("#modal_modify_mode input[type='radio']:checked").val();
 
-  if ( mode_type == "intervals" ) {
+  if ( mode_type == "intervals" || mode_type == "mos") {
 
     // get the total number of notes in the mode
     var mode_sum = mode.reduce(function(a, b) { return a + b; }, 0);


### PR DESCRIPTION
This feature calculates a MOS scale based off of the number of notes in the tuning and user-selected generator degree and size, and applies it to the mode input box. This makes it really easy to take a large ET and get a MOS subscale out of it. 

The rotation buttons allow a user to simply shift the mode left or right. 

**Requesting help for the stylization of the rotation buttons!**