### PR TITLE
Add exporters for Harmor and Sytrus

### DIFF
--- a/guide.htm
+++ b/guide.htm
@@ -200,6 +200,8 @@
               <li><a href="#maxmsp">Max/MSP coll (.txt)</a></li>
               <li><a href="#puredata">PureData text (.txt)</a></li>
               <li><a href="#kontakt">Kontakt script (.txt)</a></li>
+              <li><a href="#harmor">Harmor Pitch Map (.fnv)</a></li>
+              <li><a href="#sytrus">Sytrus Pitch Map (.fnv)</a></li>
             </ul>
           </li>
           <li><a href="#presets">Presets</a></li>
@@ -311,6 +313,21 @@
     <p>Kontakt's scripting environment allows you to retune each key to any pitch. Scale Workshop can export this script
       for you automatically. Once exported, copy and paste the contents of the script into the script editor of your
       Kontakt instrument.</p>
+
+    <h4 id="harmor">Harmor Pitch Map (.fnv)</h4>
+    <p>Harmor allows retuning keys from C0 to C10 for up to 5 octaves up or down from 12 EDO.
+      To do so, go to the "Pitch" tab, then "Keyboard mapping".
+      Click the small arrow at the bottom left and select "Open State File...".
+      From there, open the file that you exported from Scale Workshop.
+      You will have to do this for every part that you use (A and/or B).</p>
+
+    <h4 id="sytrus">Sytrus Pitch Map (.fnv)</h4>
+    <p>Sytrus allows retuning keys from C0 to C10 for up to 4 octaves up or down from 12 EDO.
+      <b>Warning: You won't be able to slide notes. If you do, the pitch will be incorrect.</b>
+      To do so, go to operator you want to retune, select the "Pitch" tab, then "Keyboard mapping".
+      Click the small arrow at the bottom left and select "Open State File...".
+      From there, open the file that you exported from Scale Workshop.
+      Then, turn PE (Pitch Envelope) knob to the maximum value.</p>
 
     <h3 id="presets">Presets</h3>
     <p>A handful of preset scales are provided as examples.</p>

--- a/index.htm
+++ b/index.htm
@@ -193,6 +193,8 @@
                                     Download PureData text Tuning (.txt)</a></li>
                             <li><a href="#kontakt-script"><span class="glyphicon glyphicon-download"
                                         aria-hidden="true"></span> Download Kontakt Tuning Script (.txt)</a></li>
+                            <li><a href="#harmor-fnv"><span class="glyphicon glyphicon-download"
+                                        aria-hidden="true"></span> Download Image-Line Harmor Pitch Map (.fnv)</a></li>
                             <li class="divider"></li>
                             <li><a href="#deflemask-reference"><span class="glyphicon glyphicon-download"
                                         aria-hidden="true"></span> Download Deflemask 'fine tune' reference (.txt)</a>

--- a/index.htm
+++ b/index.htm
@@ -194,7 +194,9 @@
                             <li><a href="#kontakt-script"><span class="glyphicon glyphicon-download"
                                         aria-hidden="true"></span> Download Kontakt Tuning Script (.txt)</a></li>
                             <li><a href="#harmor-fnv"><span class="glyphicon glyphicon-download"
-                                        aria-hidden="true"></span> Download Image-Line Harmor Pitch Map (.fnv)</a></li>
+                                        aria-hidden="true"></span> Download Harmor Pitch Map (.fnv)</a></li>
+                            <li><a href="#sytrus-fnv"><span class="glyphicon glyphicon-download"
+                                        aria-hidden="true"></span> Download Sytrus Pitch Map (.fnv)</a></li>
                             <li class="divider"></li>
                             <li><a href="#deflemask-reference"><span class="glyphicon glyphicon-download"
                                         aria-hidden="true"></span> Download Deflemask 'fine tune' reference (.txt)</a>

--- a/src/js/exporters.js
+++ b/src/js/exporters.js
@@ -284,7 +284,7 @@ function exportImageLinePitchMap(range) {
   const NB_NOTES = 121 // IL products can only retune from C0 to C10
   const HEADER_BYTES = Uint8Array.from([3, 0, 0, 0, 3, 0, 0, 0, NB_NOTES, 0, 0, 0])
   const ENDING_BYTES = Uint8Array.from([0, 0, 0, 0, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255])
-  const X_STRIDE = 1/121 // constant x offset from one point to the next
+  const X_STRIDE = 1/NB_NOTES // constant x offset from one point to the next
   const CURVE_DATA = 33554432 // curve data for straight line, observed experimentally
 
   const tuningTable = model.get('tuning table')

--- a/src/js/scaleworkshop.js
+++ b/src/js/scaleworkshop.js
@@ -32,6 +32,7 @@ import {
   exportMaxMspColl,
   exportPdText,
   exportKontaktScript,
+  exportImageLineHarmorPitchMap,
   exportReferenceDeflemask,
   exportUrl
 } from './exporters.js'
@@ -865,6 +866,9 @@ jQuery('#export-buttons').on('click', 'a', e => {
       break
     case 'kontakt-script':
       exportKontaktScript()
+      break
+    case 'harmor-fnv':
+      exportImageLineHarmorPitchMap()
       break
     case 'deflemask-reference':
       exportReferenceDeflemask()

--- a/src/js/scaleworkshop.js
+++ b/src/js/scaleworkshop.js
@@ -32,7 +32,8 @@ import {
   exportMaxMspColl,
   exportPdText,
   exportKontaktScript,
-  exportImageLineHarmorPitchMap,
+  exportHarmorPitchMap,
+  exportSytrusPitchMap,
   exportReferenceDeflemask,
   exportUrl
 } from './exporters.js'
@@ -868,7 +869,10 @@ jQuery('#export-buttons').on('click', 'a', e => {
       exportKontaktScript()
       break
     case 'harmor-fnv':
-      exportImageLineHarmorPitchMap()
+      exportHarmorPitchMap()
+      break
+    case 'sytrus-fnv':
+      exportSytrusPitchMap()
       break
     case 'deflemask-reference':
       exportReferenceDeflemask()


### PR DESCRIPTION
This PR adds exporters for Image-Line's Harmor and Sytrus, as well as docs for how to use them.
While Harmor does support .scl import, it doesn't allow changing the base frequency or MIDI note, making it hard to use in some projects.
Sytrus on the other hand does not have .scl import at all.

However both synths have a "pitch keyboard mapping" envelope that can offset pitches for each MIDI key from C0 to C10.
These exporters add support for .fnv files, which are the mapping files for these synths.

Harmor and Sytrus each need different .fnv files to work, because Harmor allows retuning up or down 5 octaves from 12 EDO, while sytrus is only 4 octaves up or down.

I have also added an optional `raw` boolean parameter to saveFile, to allow saving binary data (Uint8Array) instead of a string.

Let me know if any changes are needed.