### PR TITLE
Use key scancode instead of key character

### DIFF
--- a/src/js/keymap.js
+++ b/src/js/keymap.js
@@ -75,6 +75,7 @@ var Keycodes = {
 var Keymap = {}
 for (var id in Layouts) {
   Keymap[id] = buildKeymapFromLayout(Layouts[id]);
+  console.log(Keymap[id])
 }
 
 function buildKeymapFromLayout(rows) {

--- a/src/js/synth.js
+++ b/src/js/synth.js
@@ -14,9 +14,29 @@ const synth = new Synth()
 //     A  S  D  F  G  H  J  K  L  ;  '  \
 //      Z  X  C  V  B  N  M  ,  .  /
 //
+const layout = [
+  "Digit1 Digit2 Digit3 Digit4 Digit5 Digit6 Digit7 Digit8 Digit9 Digit0 Minus Equal",
+  "KeyQ KeyW KeyE KeyR KeyT KeyY KeyU KeyI KeyO KeyP BracketLeft BracketRight",
+  "KeyA KeyS KeyD KeyF KeyG KeyH KeyJ KeyK KeyL Semicolon Quote Backquote",
+  "KeyZ KeyX KeyC KeyV KeyB KeyN KeyM Comma Period Slash",
+]
+function buildKeymapFromLayout(rows) {
+  var map = {}
+  for (var r = rows.length - 1; r >= 0; r--) {
+    var row = rows[r].split(" ");
+    var rowId = rows.length - r - 2;
+    for (var c = 0; c < row.length; c++) {
+      var keycode = row[c];
+      map[keycode] = [rowId, c];
+    }
+  }
+  return map;
+}
+const keymap = buildKeymapFromLayout(layout)
 function keycode_to_midinote(keycode) {
   // get row/col vals from the keymap
-  var key = synth.keymap[keycode];
+
+  var key = keymap[keycode];
 
   if (R.isNil(key)) {
     // return false if there is no note assigned to this key
@@ -61,11 +81,11 @@ document.addEventListener("keydown", function (event) {
   }
 
   // bail, if a modifier is pressed alongside the key
-  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey || event.repeat) {
     return false;
   }
 
-  const midiNote = keycode_to_midinote(event.which); // midi note number 0-127
+  const midiNote = keycode_to_midinote(event.code); // midi note number 0-127
   const velocity = 100
 
   if (midiNote !== false) {
@@ -77,10 +97,10 @@ document.addEventListener("keydown", function (event) {
 // KEYUP -- capture keyboard input
 document.addEventListener("keyup", function (event) {
   // bail, if a modifier is pressed alongside the key
-  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) {
+  if (event.ctrlKey || event.shiftKey || event.altKey || event.metaKey || event.repeat) {
     return false;
   }
-  const midiNote = keycode_to_midinote(event.which)
+  const midiNote = keycode_to_midinote(event.code)
   if (midiNote !== false) {
     event.preventDefault();
     synth.noteOff(midiNote);


### PR DESCRIPTION
Currently, scale workshop uses the property KeyboardEvents.which (deprecated name of KeyboardEvents.key), this makes key identification dependent of the user's keyboard layout.
However there is now a more appropriate property which is KeyboardEvent.code, which gives the physical position of the key.

Right now I have just added some keymapping code to synth.js as a quick proof of concept, so I can get guidance on how to actually implement the change.

I have some doubts about how MacOS handles the .code property however.
[According to this](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code/code_values), it may not give the actual physical key position, but I may be misunderstanding the statement.
If a MacOS user can check if my fork works with different keyboard layouts it would be very useful.

If it works on MacOS, I don't see a reason to keep the keyboard layout handling code/dropdown. Otherwise, it may still be needed as a special case.