### PR TITLE
Add Colemak-DH support

### DIFF
--- a/src/js/keymap.js
+++ b/src/js/keymap.js
@@ -47,6 +47,14 @@ var Layouts = {
     "ARSTDHNEIO'\\",
     "ZXCVBKM,./"
   ],
+  
+  // Colemak DH-m keyboard
+  CO_DH: [
+    "1234567890-=",
+    "QWFPBJLUY;[]\\",
+    "ARSTGMNEIO'",
+    "ZXCDVKH,./"
+  ]
 };
 
 // Map of irregular keycodes


### PR DESCRIPTION
Colemak DH is the most common mod of colemak and either support should be added like this or the ability to upload custom keymaps as json files should be added (happy to try to implement this feature if it's wanted)