### PR TITLE
adjusted modify_rotate to preserve nonlinear scale data

### DIFF
--- a/src/js/modifiers.js
+++ b/src/js/modifiers.js
@@ -275,23 +275,24 @@ function modify_rotate() {
   console.log(transposer)
   console.log(equave)
 
-  // transpose each line, mod equave
-  for (let i = 0; i < lines.length; i++) {
-    if (i !== degree) {
-      lines[i] = moduloLine(transposeLine(lines[i], transposer), equave)
-    } else {
-      lines[i] = equave
-    }
-    console.log(i)
+  let rotatedLines = []
+
+  // transpose lines, mod equave
+  // start on degree after transposer/new root, cycle around and stop before transposer
+  for (let i = 1; i < lines.length; i++) {
+    let deg = (i + degree) % lines.length
+    let index = i - 1
+    rotatedLines[index] = moduloLine(transposeLine(lines[deg], transposer), equave)
+    console.log(index)
     console.log(degree)
   }
-
-  // sort resulting scale
-  lines = scaleSort(lines)
+  
+  // add equave
+  rotatedLines.push(equave)
   console.log(lines)
 
   // update tuning input field with new tuning
-  jQuery('#txt_tuning_data').val(lines.join(unix_newline))
+  jQuery('#txt_tuning_data').val(rotatedLines.join(unix_newline))
   parse_tuning_data()
   jQuery('#modal_modify_rotate').dialog('close')
 

--- a/src/js/modifiers.js
+++ b/src/js/modifiers.js
@@ -272,8 +272,6 @@ function modify_rotate() {
   let degree = parseInt(jQuery('#input_rotate_new_1_1').val())
   let transposer = negateLine(lines[degree])
   let equave = lines[lines.length - 1]
-  console.log(transposer)
-  console.log(equave)
 
   let rotatedLines = []
 
@@ -281,15 +279,12 @@ function modify_rotate() {
   // start on degree after transposer/new root, cycle around and stop before transposer
   for (let i = 1; i < lines.length; i++) {
     let deg = (i + degree) % lines.length
-    let index = i - 1
-    rotatedLines[index] = moduloLine(transposeLine(lines[deg], transposer), equave)
-    console.log(index)
-    console.log(degree)
+    let scaleIndex = i - 1
+    rotatedLines[scaleIndex] = moduloLine(transposeLine(lines[deg], transposer), equave)
   }
   
   // add equave
   rotatedLines.push(equave)
-  console.log(lines)
 
   // update tuning input field with new tuning
   jQuery('#txt_tuning_data').val(rotatedLines.join(unix_newline))


### PR DESCRIPTION
Fix for #140 

Instead of transposing in-place, we start transposing on the line after the new root through the equave. The transposed equave becomes the degree by which you can use to invert the rotation. Then we cycle back to the beginning of the scale and transpose up to the new root. Then we push the original equave to the end of the scale.