### PR TITLE
Make brightness waveform more rounded

### DIFF
--- a/src/js/synth/Synth.js
+++ b/src/js/synth/Synth.js
@@ -30,36 +30,32 @@ class Synth {
       // set up custom waveforms
       this.custom_waveforms = {
         warm1: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.2, 0.2, 0.2, 0.1, 0.1, 0.05]),
-          new Float32Array([0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
+          new Float32Array([0, 10, 2, 2, 2, 1, 1, 0.5]),
+          new Float32Array([0, 0, 0, 0, 0, 0, 0, 0])
         ),
         warm2: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.5, 0.333, 0.2, 0.1]),
-          new Float32Array([0, 0, 0.0, 0.0, 0.0, 0.0])
+          new Float32Array([0, 10, 5, 3.33, 2, 1]),
+          new Float32Array([0, 0, 0, 0, 0, 0])
         ),
         warm3: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.5, 0.5, 0.3]),
-          new Float32Array([0, 0, 0.0, 0.0, 0.0])
+          new Float32Array([0, 10, 5, 5, 3]),
+          new Float32Array([0, 0, 0, 0, 0])
         ),
         warm4: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.2, 0.2, 0.1]),
-          new Float32Array([0, 0, 0.0, 0.0, 0.0])
+          new Float32Array([0, 10, 2, 2, 1]),
+          new Float32Array([0, 0, 0, 0, 0])
         ),
         octaver: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.5, 0, 0.333, 0, 0, 0, 0.25, 0, 0, 0, 0, 0, 0, 0, 0.166]),
+          new Float32Array([0, 1000, 500, 0, 333, 0, 0, 0, 250, 0, 0, 0, 0, 0, 0, 0, 166]),
           new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         ),
         brightness: this.audioCtx.createPeriodicWave(
-          new Float32Array([
-            0, 1, 0, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.1, 0.1, 0.1, 0.1, 0.1
-          ]),
-          new Float32Array([
-            0, 0, 0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
-          ])
+          new Float32Array([0, 10, 0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1, 1, 1, 1, 1, 0.75, 0.5, 0.2, 0.1]),
+          new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         ),
         harmonicbell: this.audioCtx.createPeriodicWave(
-          new Float32Array([0, 1, 0.2, 0.2, 0.2, 0.2, 0, 0, 0, 0, 0, 0.7]),
-          new Float32Array([0, 0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0, 0, 0, 0])
+          new Float32Array([0, 10, 2, 2, 2, 2, 0, 0, 0, 0, 0, 7]),
+          new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         ),
         semisine: this.audioCtx.createPeriodicWave(
           new Float32Array([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),


### PR DESCRIPTION
Add a few more harmonics to the custom waveforms to give them a more rounded sound.
Take advantage of automatic normalization to spell the periodic waves with mostly integers.