### PR TITLE
Fix semisine waveform

### DIFF
--- a/src/js/synth/Synth.js
+++ b/src/js/synth/Synth.js
@@ -73,8 +73,8 @@ class Synth {
         semisineCosineComponents[n] = 1 / (1 - 4*n*n);
       }
       this.custom_waveforms.semisine = this.audioCtx.createPeriodicWave(
-        semisineSineComponents,
-        semisineCosineComponents
+        semisineCosineComponents,
+        semisineSineComponents
       );
 
       // set up master gain


### PR DESCRIPTION
Swap the order of the real and imaginary parts of semisine to produce the intended waveform in the time domain.